### PR TITLE
fix proverbs state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
     handler: ({ proverb }) => {
       setState({
         ...state,
-        proverbs: [...state.proverbs, proverb],
+        proverbs: [...(state.proverbs || []), proverb],
       });
     },
   });
@@ -99,7 +99,7 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
               <button 
                 onClick={() => setState({
                   ...state,
-                  proverbs: state.proverbs?.filter((_, i) => i !== index),
+                  proverbs: (state.proverbs || []).filter((_, i) => i !== index),
                 })}
                 className="absolute right-3 top-3 opacity-0 group-hover:opacity-100 transition-opacity 
                   bg-red-500 hover:bg-red-600 text-white rounded-full h-6 w-6 flex items-center justify-center"


### PR DESCRIPTION
When sending a chat that updates the `proverbs` state, there is an error in the frontend:

```
 Error: Failed to execute action addProverb: TypeError: state.proverbs is not iterable
      at createConsoleError (http://localhost:3000/_next/static/chunks/c412d_next_dist_client_b5ec818c._.js:882:71)
      at handleConsoleError (http://localhost:3000/_next/static/chunks/c412d_next_dist_client_b5ec818c._.js:1058:54)
      at console.error (http://localhost:3000/_next/static/chunks/c412d_next_dist_client_b5ec818c._.js:1223:57)
      at useChat.useAsyncCallback[runChatCompletion].executeActionFromMessage
  (http://localhost:3000/_next/static/chunks/b0ba2_%40copilotkit_react-core_dist_a0202b27._.js:3115:61)
      at http://localhost:3000/_next/static/chunks/b0ba2_%40copilotkit_react-core_dist_a0202b27._.js:3452:13
      at Generator.throw (<anonymous>)
      at rejected (http://localhost:3000/_next/static/chunks/b0ba2_%40copilotkit_react-core_dist_a0202b27._.js:106:37)
```

This fixes the issue.